### PR TITLE
Updates rad-security connect application id

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_rad_security_app_id"></a> [rad\_security\_app\_id](#input\_rad\_security\_app\_id) | The ID of the Rad Security Azure application. | `string` | `"4ba48a95-c5da-41d1-897a-57bdf7e34e5b"` | no |
+| <a name="input_rad_security_app_id"></a> [rad\_security\_app\_id](#input\_rad\_security\_app\_id) | The ID of the Rad Security Azure application. | `string` | `"55bd48fb-0aea-469d-b464-b5aa1490941d"` | no |
 | <a name="input_rad_security_role_name"></a> [rad\_security\_role\_name](#input\_rad\_security\_role\_name) | Name of custom role to assume | `string` | `"rad-security-connect"` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "rad_security_app_id" {
   type        = string
-  default     = "4ba48a95-c5da-41d1-897a-57bdf7e34e5b"
+  default     = "55bd48fb-0aea-469d-b464-b5aa1490941d"
   description = "The ID of the Rad Security Azure application."
 }
 


### PR DESCRIPTION
The `rad_security_app_id` input default currently set to the testing application id. It needs to be the prd id by default. 