### PR TITLE
Removes the need for duplicate roles in each account

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,4 @@
 locals {
   subscriptions      = length(var.azure_subscriptions) == 0 ? toset([data.azurerm_subscription.primary.id]) : toset(var.azure_subscriptions)
-  subscriptions_list = tolist(local.subscriptions)                               # Convert to list
-  subscriptions_map  = { for idx, sub in local.subscriptions_list : idx => sub } # Convert list to map
+  subscriptions_list = tolist(local.subscriptions) # Convert to list
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,5 @@
 locals {
-  subscriptions = length(var.azure_subscriptions) == 0 ? toset([data.azurerm_subscription.primary.id]) : toset(var.azure_subscriptions)
+  subscriptions      = length(var.azure_subscriptions) == 0 ? toset([data.azurerm_subscription.primary.id]) : toset(var.azure_subscriptions)
+  subscriptions_list = tolist(local.subscriptions)                               # Convert to list
+  subscriptions_map  = { for idx, sub in local.subscriptions_list : idx => sub } # Convert list to map
 }

--- a/role.tf
+++ b/role.tf
@@ -1,9 +1,7 @@
 resource "azurerm_role_definition" "rad_security" {
-  for_each = local.subscriptions
-
   name        = var.rad_security_role_name
-  scope       = each.value
   description = "Allow Rad Security read access to your cloud account"
+  scope       = local.subscriptions_list[0] # Use list indexing
 
   permissions {
     actions = [
@@ -13,12 +11,14 @@ resource "azurerm_role_definition" "rad_security" {
     ]
     not_actions = []
   }
+
+  assignable_scopes = local.subscriptions_list # Use list directly
 }
 
 resource "azurerm_role_assignment" "rad_security" {
-  for_each = local.subscriptions
+  for_each = local.subscriptions_map
 
   scope              = each.value
-  role_definition_id = azurerm_role_definition.rad_security[each.key].role_definition_resource_id
+  role_definition_id = azurerm_role_definition.rad_security.role_definition_resource_id
   principal_id       = azuread_service_principal.rad_security.object_id
 }

--- a/role.tf
+++ b/role.tf
@@ -1,7 +1,7 @@
 resource "azurerm_role_definition" "rad_security" {
   name        = var.rad_security_role_name
   description = "Allow Rad Security read access to your cloud account"
-  scope       = local.subscriptions_list[0] # Use list indexing
+  scope       = local.subscriptions_list[0]
 
   permissions {
     actions = [
@@ -12,13 +12,13 @@ resource "azurerm_role_definition" "rad_security" {
     not_actions = []
   }
 
-  assignable_scopes = local.subscriptions_list # Use list directly
+  assignable_scopes = local.subscriptions_list
 }
 
 resource "azurerm_role_assignment" "rad_security" {
-  for_each = local.subscriptions_map
+  count = length(local.subscriptions_list)
 
-  scope              = each.value
+  scope              = local.subscriptions_list[count.index]
   role_definition_id = azurerm_role_definition.rad_security.role_definition_resource_id
   principal_id       = azuread_service_principal.rad_security.object_id
 }


### PR DESCRIPTION
Sets `assignable_scopes` in the Role definition to use all subscriptions. The local variable finessing is unfortunately necessary. Terraform rejects resources using `local.subscriptions[0]` directly due to it being nondeterministic in the  azurerm_role_definition. 

